### PR TITLE
test(chat): expand room service and controller coverage

### DIFF
--- a/src/main/java/com/example/mafiagame/chat/domain/ChatRoom.java
+++ b/src/main/java/com/example/mafiagame/chat/domain/ChatRoom.java
@@ -41,6 +41,7 @@ public class ChatRoom implements Serializable {
         this.hostId = hostId;
         this.hostName = hostName;
         this.participants = new ArrayList<>();
+        this.maxPlayers = 12;
     }
 
     /**

--- a/src/test/java/com/example/mafiagame/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/example/mafiagame/chat/controller/ChatRoomControllerTest.java
@@ -1,0 +1,160 @@
+package com.example.mafiagame.chat.controller;
+
+import com.example.mafiagame.chat.dto.ChatMessage;
+import com.example.mafiagame.chat.dto.request.JoinRoomRequest;
+import com.example.mafiagame.chat.dto.request.LeaveRoomRequest;
+import com.example.mafiagame.chat.service.ChatRoomService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ChatRoomControllerTest {
+
+    @Mock
+    private ChatRoomService chatRoomService;
+
+    @Mock
+    private SimpMessageHeaderAccessor headerAccessor;
+
+    @Mock
+    private Principal principal;
+
+    @InjectMocks
+    private ChatRoomController chatRoomController;
+
+    private Map<String, Object> sessionAttributes;
+
+    @BeforeEach
+    void setUp() {
+        sessionAttributes = new HashMap<>();
+        sessionAttributes.put("user", principal);
+    }
+
+    @Test
+    @DisplayName("메시지 전송 - 성공")
+    void sendMessage_success() {
+        // given
+        when(principal.getName()).thenReturn("testUser");
+        ChatMessage message = ChatMessage.builder()
+                .roomId("room-123")
+                .content("안녕하세요")
+                .build();
+        when(headerAccessor.getSessionAttributes()).thenReturn(sessionAttributes);
+
+        // when
+        chatRoomController.sendMessage(message, headerAccessor);
+
+        // then
+        verify(chatRoomService).processAndBroadcastMessage(message, "testUser");
+    }
+
+    @Test
+    @DisplayName("메시지 전송 - Principal 없음")
+    void sendMessage_noPrincipal() {
+        // given
+        ChatMessage message = ChatMessage.builder()
+                .roomId("room-123")
+                .content("안녕하세요")
+                .build();
+        when(headerAccessor.getSessionAttributes()).thenReturn(null);
+
+        // when
+        chatRoomController.sendMessage(message, headerAccessor);
+
+        // then
+        verify(chatRoomService, never()).processAndBroadcastMessage(any(), anyString());
+    }
+
+    @Test
+    @DisplayName("개인 메시지 전송 - 성공")
+    void sendPrivateMessage_success() {
+        // given
+        when(principal.getName()).thenReturn("testUser");
+        ChatMessage message = ChatMessage.builder()
+                .roomId("room-123")
+                .recipient("otherUser")
+                .content("비밀 대화")
+                .build();
+        when(headerAccessor.getSessionAttributes()).thenReturn(sessionAttributes);
+
+        // when
+        chatRoomController.sendPrivateMessage(message, headerAccessor);
+
+        // then
+        verify(chatRoomService).processAndPrivateMessage(message, "testUser");
+    }
+
+    @Test
+    @DisplayName("채팅방 참여 - 성공")
+    void joinRoom_success() {
+        // given
+        when(principal.getName()).thenReturn("testUser");
+        Map<String, Object> payload = Map.of("roomId", "room-123");
+        when(headerAccessor.getSessionAttributes()).thenReturn(sessionAttributes);
+
+        // when
+        chatRoomController.joinRoom(payload, headerAccessor);
+
+        // then
+        ArgumentCaptor<JoinRoomRequest> requestCaptor = ArgumentCaptor.forClass(JoinRoomRequest.class);
+        verify(chatRoomService).userJoin(requestCaptor.capture());
+        JoinRoomRequest capturedRequest = requestCaptor.getValue();
+        assertThat(capturedRequest.roomId()).isEqualTo("room-123");
+        assertThat(capturedRequest.userId()).isEqualTo("testUser");
+    }
+
+    @Test
+    @DisplayName("채팅방 탈퇴 - 성공")
+    void leaveRoom_success() {
+        // given
+        when(principal.getName()).thenReturn("testUser");
+        Map<String, Object> payload = Map.of("roomId", "room-123");
+        when(headerAccessor.getSessionAttributes()).thenReturn(sessionAttributes);
+
+        // when
+        chatRoomController.leaveRoom(payload, headerAccessor);
+
+        // then
+        ArgumentCaptor<LeaveRoomRequest> requestCaptor = ArgumentCaptor.forClass(LeaveRoomRequest.class);
+        verify(chatRoomService).userLeave(requestCaptor.capture());
+        LeaveRoomRequest capturedRequest = requestCaptor.getValue();
+        assertThat(capturedRequest.roomId()).isEqualTo("room-123");
+        assertThat(capturedRequest.userId()).isEqualTo("testUser");
+    }
+
+    @Test
+    @DisplayName("WebSocket 연결 끊김 이벤트 처리 - 성공")
+    void handleWebSocketDisconnectListener_success() {
+        // given
+        when(principal.getName()).thenReturn("testUser");
+        Message<byte[]> message = MessageBuilder.withPayload(new byte[0])
+                .setHeader(SimpMessageHeaderAccessor.SESSION_ATTRIBUTES, sessionAttributes)
+                .build();
+
+        SessionDisconnectEvent event = mock(SessionDisconnectEvent.class);
+        when(event.getMessage()).thenReturn(message);
+
+        // when
+        chatRoomController.handleWebSocketDisconnectListener(event);
+
+        // then
+        verify(chatRoomService).handleDisconnect("testUser");
+    }
+}

--- a/src/test/java/com/example/mafiagame/chat/controller/ChatRoomRestControllerTest.java
+++ b/src/test/java/com/example/mafiagame/chat/controller/ChatRoomRestControllerTest.java
@@ -1,0 +1,194 @@
+package com.example.mafiagame.chat.controller;
+
+import com.example.mafiagame.chat.domain.ChatRoom;
+import com.example.mafiagame.chat.domain.ChatUser;
+import com.example.mafiagame.chat.dto.request.CreateRoomRequest;
+import com.example.mafiagame.chat.dto.request.JoinRoomRequest;
+import com.example.mafiagame.chat.service.ChatRoomService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+    controllers = ChatRoomRestController.class,
+    excludeAutoConfiguration = {
+        SecurityAutoConfiguration.class,
+        SecurityFilterAutoConfiguration.class,
+        OAuth2ClientAutoConfiguration.class,
+        org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientWebSecurityAutoConfiguration.class
+    },
+    excludeFilters = @ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE,
+        classes = {
+            com.example.mafiagame.global.config.SecurityConfig.class,
+            com.example.mafiagame.global.jwt.JwtRequestFilter.class,
+            com.example.mafiagame.global.oauth2.CustomOAuth2UserService.class,
+            com.example.mafiagame.global.oauth2.OAuth2SuccessHandler.class
+        }
+    )
+)
+@AutoConfigureMockMvc(addFilters = false)
+class ChatRoomRestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ChatRoomService chatRoomService;
+
+    private ChatRoom chatRoom;
+
+    @BeforeEach
+    void setUp() {
+        chatRoom = ChatRoom.builder()
+                .roomId("room-123")
+                .roomName("테스트 마피아 방")
+                .hostId("testUser")
+                .hostName("방장닉네임")
+                .participants(new ArrayList<>(List.of(
+                        ChatUser.builder().userId("testUser").userName("방장닉네임").isHost(true).build()
+                )))
+                .build();
+    }
+
+    @Test
+    @DisplayName("채팅방 생성 - 성공")
+    void createRoom_success() throws Exception {
+        // given
+        CreateRoomRequest request = new CreateRoomRequest("테스트 마피아 방");
+        when(chatRoomService.createRoom(any(CreateRoomRequest.class), eq("testUser"))).thenReturn(chatRoom);
+
+        // when & then
+        mockMvc.perform(post("/api/chat/rooms")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .principal(new UsernamePasswordAuthenticationToken("testUser", "")))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.roomId").value("room-123"))
+                .andExpect(jsonPath("$.roomName").value("테스트 마피아 방"))
+                .andExpect(jsonPath("$.hostId").value("testUser"))
+                .andExpect(jsonPath("$.hostName").value("방장닉네임"));
+
+        verify(chatRoomService).createRoom(any(CreateRoomRequest.class), eq("testUser"));
+    }
+
+    @Test
+    @DisplayName("채팅방 입장 - 성공")
+    void joinRoom_success() throws Exception {
+        // given
+        JoinRoomRequest request = new JoinRoomRequest("room-123", "testUser");
+
+        // when & then
+        mockMvc.perform(post("/api/chat/rooms/room-123/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .principal(new UsernamePasswordAuthenticationToken("testUser", "")))
+                .andExpect(status().isOk());
+
+        verify(chatRoomService).userJoin(any(JoinRoomRequest.class));
+    }
+
+    @Test
+    @DisplayName("채팅방 입장 - 방 ID 불일치로 예외 발생")
+    void joinRoom_mismatchedRoomId() throws Exception {
+        // given
+        JoinRoomRequest request = new JoinRoomRequest("mismatched-room", "testUser");
+
+        // when & then
+        mockMvc.perform(post("/api/chat/rooms/room-123/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .principal(new UsernamePasswordAuthenticationToken("testUser", "")))
+                .andExpect(status().isInternalServerError());
+
+        verify(chatRoomService, never()).userJoin(any());
+    }
+
+    @Test
+    @DisplayName("채팅방 목록 조회 - 성공")
+    void getAllRooms_success() throws Exception {
+        // given
+        when(chatRoomService.getAllRooms()).thenReturn(List.of(chatRoom));
+
+        // when & then
+        mockMvc.perform(get("/api/chat/rooms"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].roomId").value("room-123"))
+                .andExpect(jsonPath("$[0].roomName").value("테스트 마피아 방"));
+
+        verify(chatRoomService).getAllRooms();
+    }
+
+    @Test
+    @DisplayName("채팅방 조회 - 존재할 때")
+    void getRoom_found() throws Exception {
+        // given
+        when(chatRoomService.getRoom("room-123")).thenReturn(chatRoom);
+
+        // when & then
+        mockMvc.perform(get("/api/chat/rooms/room-123"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.roomId").value("room-123"))
+                .andExpect(jsonPath("$.roomName").value("테스트 마피아 방"));
+
+        verify(chatRoomService).getRoom("room-123");
+    }
+
+    @Test
+    @DisplayName("채팅방 조회 - 존재하지 않을 때 404")
+    void getRoom_notFound() throws Exception {
+        // given
+        when(chatRoomService.getRoom("non-existent")).thenReturn(null);
+
+        // when & then
+        mockMvc.perform(get("/api/chat/rooms/non-existent"))
+                .andExpect(status().isNotFound());
+
+        verify(chatRoomService).getRoom("non-existent");
+    }
+
+    @Test
+    @DisplayName("채팅방 검색 - 성공")
+    void searchRooms_success() throws Exception {
+        // given
+        when(chatRoomService.searchRooms("테스트")).thenReturn(List.of(chatRoom));
+
+        // when & then
+        mockMvc.perform(get("/api/chat/rooms/search")
+                        .param("keyword", "테스트"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].roomId").value("room-123"));
+
+        verify(chatRoomService).searchRooms("테스트");
+    }
+}

--- a/src/test/java/com/example/mafiagame/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/example/mafiagame/chat/service/ChatRoomServiceTest.java
@@ -1,0 +1,586 @@
+package com.example.mafiagame.chat.service;
+
+import com.example.mafiagame.chat.domain.ChatRoom;
+import com.example.mafiagame.chat.domain.ChatUser;
+import com.example.mafiagame.chat.dto.ChatMessage;
+import com.example.mafiagame.chat.dto.MessageType;
+import com.example.mafiagame.chat.dto.request.CreateRoomRequest;
+import com.example.mafiagame.chat.dto.request.JoinRoomRequest;
+import com.example.mafiagame.chat.dto.request.LeaveRoomRequest;
+import com.example.mafiagame.game.domain.entity.Game;
+import com.example.mafiagame.game.domain.state.GamePhase;
+import com.example.mafiagame.game.domain.state.GameState;
+import com.example.mafiagame.game.domain.state.GamePlayerState;
+import com.example.mafiagame.game.domain.state.PlayerRole;
+import com.example.mafiagame.game.repository.GameStateRepository;
+import com.example.mafiagame.game.service.GameQueryService;
+import com.example.mafiagame.game.service.SuggestionService;
+import com.example.mafiagame.global.error.CommonException;
+import com.example.mafiagame.global.error.ErrorCode;
+import com.example.mafiagame.global.service.RedisService;
+import com.example.mafiagame.user.domain.Users;
+import com.example.mafiagame.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ChatRoomServiceTest {
+
+    @Mock
+    private UserService userService;
+    @Mock
+    private GameQueryService gameQueryService;
+    @Mock
+    private WebSocketMessageBroadcaster messageBroadcaster;
+    @Mock
+    private SuggestionService suggestionService;
+    @Mock
+    private GameStateRepository gameStateRepository;
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+    @Mock
+    private RedissonClient redissonClient;
+    @Mock
+    private RedisService redisService;
+
+    @Mock
+    private RLock rLock;
+    @Mock
+    private ListOperations<String, String> listOperations;
+
+    @InjectMocks
+    private ChatRoomService chatRoomService;
+
+    private Users host;
+    private Users guest;
+    private ChatRoom chatRoom;
+
+    @BeforeEach
+    void setUp() {
+        host = Users.builder()
+                .userId(1L)
+                .userLoginId("hostUser")
+                .nickname("방장닉네임")
+                .build();
+
+        guest = Users.builder()
+                .userId(2L)
+                .userLoginId("guestUser")
+                .nickname("게스트닉네임")
+                .build();
+
+        chatRoom = new ChatRoom("테스트방", host.getUserLoginId(), host.getNickname());
+        chatRoom.setRoomId("room-123");
+        chatRoom.addParticipant(ChatUser.builder()
+                .userId(host.getUserLoginId())
+                .userName(host.getNickname())
+                .isHost(true)
+                .build());
+    }
+
+    // ================== createRoom Tests ================== //
+
+    @Test
+    @DisplayName("방 생성 - 성공")
+    void createRoom_success() {
+        // given
+        CreateRoomRequest request = new CreateRoomRequest("새로운 마피아 방");
+        when(userService.getUserByLoginId("hostUser")).thenReturn(host);
+
+        // when
+        ChatRoom createdRoom = chatRoomService.createRoom(request, "hostUser");
+
+        // then
+        assertThat(createdRoom).isNotNull();
+        assertThat(createdRoom.getRoomName()).isEqualTo("새로운 마피아 방");
+        assertThat(createdRoom.getHostId()).isEqualTo("hostUser");
+        assertThat(createdRoom.getParticipants()).hasSize(1);
+        assertThat(createdRoom.getParticipants().get(0).getUserId()).isEqualTo("hostUser");
+        verify(redisService).saveChatRoom(any(ChatRoom.class));
+        verify(redisService).saveUserSession(eq("hostUser"), eq(createdRoom.getRoomId()), any());
+    }
+
+    @Test
+    @DisplayName("방 생성 - 세션 저장 중 예외 발생 시 방 삭제 및 예외 던짐")
+    void createRoom_rollbackOnSessionError() {
+        // given
+        CreateRoomRequest request = new CreateRoomRequest("새로운 마피아 방");
+        when(userService.getUserByLoginId("hostUser")).thenReturn(host);
+        doThrow(new RuntimeException("Redis error")).when(redisService).saveUserSession(anyString(), anyString(), any());
+
+        // when & then
+        assertThatThrownBy(() -> chatRoomService.createRoom(request, "hostUser"))
+                .isInstanceOf(CommonException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CHAT_ROOM_CREATE_FAILED);
+
+        verify(redisService).deleteChatRoom(anyString());
+    }
+
+    // ================== userJoin Tests ================== //
+
+    @Test
+    @DisplayName("방 입장 - 방 정보가 없는 경우(null/공백)")
+    void userJoin_invalidRoomId() {
+        // given
+        JoinRoomRequest request = new JoinRoomRequest("   ", "guestUser");
+
+        // when
+        chatRoomService.userJoin(request);
+
+        // then
+        verify(messageBroadcaster).sendError("guestUser", "방 정보가 올바르지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("방 입장 - 이미 다른 방에 속해 있는 경우")
+    void userJoin_alreadyInAnotherRoom() {
+        // given
+        JoinRoomRequest request = new JoinRoomRequest("room-123", "guestUser");
+        when(redisService.getUserRoomId("guestUser")).thenReturn("room-456");
+
+        // when
+        chatRoomService.userJoin(request);
+
+        // then
+        verify(messageBroadcaster).sendError("guestUser", "이미 다른 방에 참여 중입니다.");
+    }
+
+    @Test
+    @DisplayName("방 입장 - 분산 락 획득 실패 시")
+    void userJoin_lockAcquisitionFail() throws InterruptedException {
+        // given
+        JoinRoomRequest request = new JoinRoomRequest("room-123", "guestUser");
+        when(redisService.getUserRoomId("guestUser")).thenReturn(null);
+        when(redissonClient.getLock("lock:room:room-123")).thenReturn(rLock);
+        when(rLock.tryLock(anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(false);
+
+        // when
+        chatRoomService.userJoin(request);
+
+        // then
+        verify(messageBroadcaster).sendError("guestUser", "잠시 후 다시 시도해주세요.");
+    }
+
+    @Test
+    @DisplayName("방 입장 - 방이 존재하지 않는 경우")
+    void userJoin_roomNotFound() throws InterruptedException {
+        // given
+        JoinRoomRequest request = new JoinRoomRequest("room-123", "guestUser");
+        when(redisService.getUserRoomId("guestUser")).thenReturn(null);
+        when(redissonClient.getLock("lock:room:room-123")).thenReturn(rLock);
+        when(rLock.tryLock(anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(true);
+        when(rLock.isHeldByCurrentThread()).thenReturn(true);
+        when(redisService.getChatRoom("room-123")).thenReturn(null);
+
+        // when
+        chatRoomService.userJoin(request);
+
+        // then
+        verify(messageBroadcaster).sendError("guestUser", "채팅방이 존재하지 않습니다.");
+        verify(rLock).unlock();
+    }
+
+    @Test
+    @DisplayName("방 입장 - 방이 가득 차거나 이미 참여 중인 경우")
+    void userJoin_roomFullOrAlreadyJoined() throws InterruptedException {
+        // given
+        JoinRoomRequest request = new JoinRoomRequest("room-123", "guestUser");
+        when(redisService.getUserRoomId("guestUser")).thenReturn(null);
+        when(redissonClient.getLock("lock:room:room-123")).thenReturn(rLock);
+        when(rLock.tryLock(anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(true);
+        when(rLock.isHeldByCurrentThread()).thenReturn(true);
+
+        ChatRoom fullRoom = ChatRoom.builder()
+                .roomId("room-123")
+                .maxPlayers(1)
+                .participants(new ArrayList<>(List.of(ChatUser.builder().userId("someHost").build())))
+                .build();
+        when(redisService.getChatRoom("room-123")).thenReturn(fullRoom);
+        when(userService.getUserByLoginId("guestUser")).thenReturn(guest);
+
+        // when
+        chatRoomService.userJoin(request);
+
+        // then
+        verify(messageBroadcaster).sendError("guestUser", "채팅방이 가득 찼거나 이미 참여 중입니다.");
+    }
+
+    @Test
+    @DisplayName("방 입장 - 성공")
+    void userJoin_success() throws InterruptedException {
+        // given
+        JoinRoomRequest request = new JoinRoomRequest("room-123", "guestUser");
+        when(redisService.getUserRoomId("guestUser")).thenReturn(null);
+        when(redissonClient.getLock("lock:room:room-123")).thenReturn(rLock);
+        when(rLock.tryLock(anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(true);
+        when(rLock.isHeldByCurrentThread()).thenReturn(true);
+        when(redisService.getChatRoom("room-123")).thenReturn(chatRoom);
+        when(userService.getUserByLoginId("guestUser")).thenReturn(guest);
+
+        // when
+        chatRoomService.userJoin(request);
+
+        // then
+        assertThat(chatRoom.getParticipants()).hasSize(2);
+        verify(redisService).saveChatRoom(chatRoom);
+        verify(redisService).saveUserSession("guestUser", "room-123", null);
+        verify(messageBroadcaster).broadcastToRoom(eq("room-123"), any(ChatMessage.class));
+        verify(messageBroadcaster).notifyRoomListUpdated();
+    }
+
+    // ================== userLeave Tests ================== //
+
+    @Test
+    @DisplayName("방 퇴장 - 방 정보가 없는 경우")
+    void userLeave_invalidRoom() {
+        // given
+        LeaveRoomRequest request = new LeaveRoomRequest(null, "guestUser");
+        when(redisService.getUserRoomId("guestUser")).thenReturn(null);
+
+        // when
+        chatRoomService.userLeave(request);
+
+        // then
+        verify(messageBroadcaster).sendError("guestUser", "방 정보가 올바르지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("방 퇴장 - 게임 진행 중으로 퇴장이 차단된 경우")
+    void userLeave_blockedByGameInProgress() throws InterruptedException {
+        // given
+        LeaveRoomRequest request = new LeaveRoomRequest("room-123", "guestUser");
+        when(redisService.getUserRoomId("guestUser")).thenReturn("room-123");
+        when(redissonClient.getLock("lock:room:room-123")).thenReturn(rLock);
+        when(rLock.tryLock(anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(true);
+        when(rLock.isHeldByCurrentThread()).thenReturn(true);
+        when(redisService.getChatRoom("room-123")).thenReturn(chatRoom);
+        when(gameQueryService.canPlayerLeaveRoom("room-123", "guestUser")).thenReturn(false);
+
+        // when
+        chatRoomService.userLeave(request);
+
+        // then
+        verify(messageBroadcaster).sendError("guestUser", "게임이 진행 중입니다. 게임이 끝날 때까지 방을 나갈 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("방 퇴장 - 방에 참여하고 있지 않은 유저 퇴장 시도 시 세션만 삭제")
+    void userLeave_notParticipantOnlyDeletesSession() throws InterruptedException {
+        // given
+        LeaveRoomRequest request = new LeaveRoomRequest("room-123", "guestUser");
+        when(redisService.getUserRoomId("guestUser")).thenReturn("room-123");
+        when(redissonClient.getLock("lock:room:room-123")).thenReturn(rLock);
+        when(rLock.tryLock(anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(true);
+        when(rLock.isHeldByCurrentThread()).thenReturn(true);
+        when(gameQueryService.canPlayerLeaveRoom("room-123", "guestUser")).thenReturn(true);
+        when(redisService.getChatRoom("room-123")).thenReturn(chatRoom); // chatRoom에는 hostUser만 있음
+
+        // when
+        chatRoomService.userLeave(request);
+
+        // then
+        verify(redisService).deleteUserSession("guestUser");
+        verify(redisService, never()).saveChatRoom(any());
+    }
+
+    @Test
+    @DisplayName("방 퇴장 - 마지막 인원이 나가서 방이 삭제되는 경우")
+    void userLeave_deleteRoomWhenEmpty() throws InterruptedException {
+        // given
+        LeaveRoomRequest request = new LeaveRoomRequest("room-123", "hostUser");
+        when(redisService.getUserRoomId("hostUser")).thenReturn("room-123");
+        when(redissonClient.getLock("lock:room:room-123")).thenReturn(rLock);
+        when(rLock.tryLock(anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(true);
+        when(rLock.isHeldByCurrentThread()).thenReturn(true);
+        when(gameQueryService.canPlayerLeaveRoom("room-123", "hostUser")).thenReturn(true);
+        when(redisService.getChatRoom("room-123")).thenReturn(chatRoom); // hostUser만 들어있는 방
+
+        // when
+        chatRoomService.userLeave(request);
+
+        // then
+        verify(redisService).deleteUserSession("hostUser");
+        verify(redisService).deleteChatRoom("room-123");
+        verify(stringRedisTemplate).delete("chat:logs:room-123");
+        verify(messageBroadcaster).notifyRoomListUpdated();
+    }
+
+    @Test
+    @DisplayName("방 퇴장 - 방장 퇴장으로 다른 사람에게 위임 및 방 정보 업데이트")
+    void userLeave_delegateHost() throws InterruptedException {
+        // given
+        chatRoom.addParticipant(ChatUser.builder()
+                .userId(guest.getUserLoginId())
+                .userName(guest.getNickname())
+                .isHost(false)
+                .build()); // hostUser, guestUser가 있는 상태
+
+        LeaveRoomRequest request = new LeaveRoomRequest("room-123", "hostUser");
+        when(redisService.getUserRoomId("hostUser")).thenReturn("room-123");
+        when(redissonClient.getLock("lock:room:room-123")).thenReturn(rLock);
+        when(rLock.tryLock(anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(true);
+        when(rLock.isHeldByCurrentThread()).thenReturn(true);
+        when(gameQueryService.canPlayerLeaveRoom("room-123", "hostUser")).thenReturn(true);
+        when(redisService.getChatRoom("room-123")).thenReturn(chatRoom);
+
+        // when
+        chatRoomService.userLeave(request);
+
+        // then
+        assertThat(chatRoom.getHostId()).isEqualTo("guestUser");
+        assertThat(chatRoom.getParticipants().get(0).isHost()).isTrue();
+        verify(redisService).saveChatRoom(chatRoom);
+        verify(messageBroadcaster).broadcastToRoom(eq("room-123"), any(ChatMessage.class));
+        verify(messageBroadcaster).sendHostChanged("room-123", "guestUser", guest.getNickname());
+        verify(messageBroadcaster).notifyRoomListUpdated();
+    }
+
+    // ================== processAndBroadcastMessage Tests ================== //
+
+    @Test
+    @DisplayName("메시지 브로드캐스트 - 페이로드 null")
+    void processAndBroadcastMessage_payloadNull() {
+        chatRoomService.processAndBroadcastMessage(null, "someUser");
+        verify(messageBroadcaster).sendError("someUser", "메시지 형식이 올바르지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("메시지 브로드캐스트 - 메시지 검증 실패(null 내용)")
+    void processAndBroadcastMessage_contentNull() {
+        ChatMessage message = ChatMessage.builder()
+                .roomId("room-123")
+                .content(null)
+                .build();
+        when(redisService.getUserRoomId("guestUser")).thenReturn("room-123");
+        when(redisService.getChatRoom("room-123")).thenReturn(chatRoom);
+
+        // guest가 chatRoom에 참여 중으로 추가해 줌
+        chatRoom.addParticipant(ChatUser.builder().userId("guestUser").build());
+
+        chatRoomService.processAndBroadcastMessage(message, "guestUser");
+        verify(messageBroadcaster).sendError("guestUser", "메시지를 입력해주세요.");
+    }
+
+    @Test
+    @DisplayName("메시지 브로드캐스트 - 채팅 권한이 없는 경우")
+    void processAndBroadcastMessage_noChatPermission() {
+        ChatMessage message = ChatMessage.builder()
+                .roomId("room-123")
+                .content("안녕하세요")
+                .build();
+        when(redisService.getUserRoomId("guestUser")).thenReturn("room-123");
+        when(redisService.getChatRoom("room-123")).thenReturn(chatRoom);
+        chatRoom.addParticipant(ChatUser.builder().userId("guestUser").build());
+        when(userService.getUserByLoginId("guestUser")).thenReturn(guest);
+        when(gameQueryService.canPlayerChat("room-123", "guestUser")).thenReturn(false);
+
+        chatRoomService.processAndBroadcastMessage(message, "guestUser");
+
+        verify(messageBroadcaster).sendError("guestUser", "지금은 채팅을 할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("메시지 브로드캐스트 - 밤 페이즈 마피아 채팅 개별 전송")
+    void processAndBroadcastMessage_mafiaNightChat() {
+        ChatMessage message = ChatMessage.builder()
+                .roomId("room-123")
+                .content("밤인데 마피아 누구 쏠까요?")
+                .build();
+        when(redisService.getUserRoomId("guestUser")).thenReturn("room-123");
+        when(redisService.getChatRoom("room-123")).thenReturn(chatRoom);
+        chatRoom.addParticipant(ChatUser.builder().userId("guestUser").build());
+        when(userService.getUserByLoginId("guestUser")).thenReturn(guest);
+        when(gameQueryService.canPlayerChat("room-123", "guestUser")).thenReturn(true);
+
+        Game game = new Game();
+        game.setGameId("game-123");
+        when(gameQueryService.getGameByRoomId("room-123")).thenReturn(game);
+
+        GamePlayerState hostPlayer = GamePlayerState.builder()
+                .playerId("hostUser")
+                .role(PlayerRole.MAFIA)
+                .isAlive(true)
+                .build();
+        GamePlayerState guestPlayer = GamePlayerState.builder()
+                .playerId("guestUser")
+                .role(PlayerRole.MAFIA)
+                .isAlive(true)
+                .build();
+        GamePlayerState otherPlayer = GamePlayerState.builder()
+                .playerId("otherUser")
+                .role(PlayerRole.CITIZEN)
+                .isAlive(true)
+                .build();
+
+        GameState gameState = GameState.builder()
+                .gameId("game-123")
+                .gamePhase(GamePhase.NIGHT_ACTION)
+                .players(List.of(hostPlayer, guestPlayer, otherPlayer))
+                .build();
+        when(gameQueryService.getGameState("game-123")).thenReturn(gameState);
+
+        // when
+        chatRoomService.processAndBroadcastMessage(message, "guestUser");
+
+        // then
+        ArgumentCaptor<ChatMessage> captor = ArgumentCaptor.forClass(ChatMessage.class);
+        verify(messageBroadcaster, times(2)).sendPrivateMessage(anyString(), captor.capture());
+        assertThat(captor.getValue().getType()).isEqualTo(MessageType.MAFIA_CHAT);
+        verify(messageBroadcaster, never()).broadcastToRoom(anyString(), any());
+    }
+
+    @Test
+    @DisplayName("메시지 브로드캐스트 - 10개 쌓였을 때 Redis Flush 및 AI suggestion 비동기 트리거")
+    void processAndBroadcastMessage_bufferFlushAndAiTrigger() {
+        when(redisService.getUserRoomId("guestUser")).thenReturn("room-123");
+        when(redisService.getChatRoom("room-123")).thenReturn(chatRoom);
+        chatRoom.addParticipant(ChatUser.builder().userId("guestUser").build());
+        when(userService.getUserByLoginId("guestUser")).thenReturn(guest);
+        when(gameQueryService.canPlayerChat("room-123", "guestUser")).thenReturn(true);
+        when(gameQueryService.getGameByRoomId("room-123")).thenReturn(null); // 일반 채팅
+        when(stringRedisTemplate.opsForList()).thenReturn(listOperations);
+
+        GameState gameState = GameState.builder()
+                .gameId("game-123")
+                .gamePhase(GamePhase.DAY_DISCUSSION)
+                .build();
+        when(gameStateRepository.findByRoomId("room-123")).thenReturn(Optional.of(gameState));
+
+        // 10번 메시지 전송
+        for (int i = 1; i <= 10; i++) {
+            ChatMessage message = ChatMessage.builder()
+                    .roomId("room-123")
+                    .content("메시지 " + i)
+                    .build();
+            chatRoomService.processAndBroadcastMessage(message, "guestUser");
+        }
+
+        // then
+        verify(messageBroadcaster, times(10)).broadcastToRoom(eq("room-123"), any(ChatMessage.class));
+        verify(stringRedisTemplate).delete("chat:logs:room-123");
+        verify(listOperations).rightPushAll(eq("chat:logs:room-123"), anyList());
+        verify(suggestionService).generateAiSuggestionsAsync("game-123", GamePhase.DAY_DISCUSSION);
+    }
+
+    // ================== processAndPrivateMessage Tests ================== //
+
+    @Test
+    @DisplayName("개인 메시지 전송 - 대상 미지정")
+    void processAndPrivateMessage_noRecipient() {
+        ChatMessage message = ChatMessage.builder()
+                .roomId("room-123")
+                .recipient(null)
+                .content("안녕")
+                .build();
+        when(redisService.getUserRoomId("guestUser")).thenReturn("room-123");
+        when(redisService.getChatRoom("room-123")).thenReturn(chatRoom);
+        chatRoom.addParticipant(ChatUser.builder().userId("guestUser").build());
+
+        chatRoomService.processAndPrivateMessage(message, "guestUser");
+
+        verify(messageBroadcaster).sendError("guestUser", "메시지를 보낼 대상을 지정해주세요.");
+    }
+
+    @Test
+    @DisplayName("개인 메시지 전송 - 자기 자신에게 보낼 때")
+    void processAndPrivateMessage_sendToSelf() {
+        ChatMessage message = ChatMessage.builder()
+                .roomId("room-123")
+                .recipient("guestUser")
+                .content("안녕")
+                .build();
+        when(redisService.getUserRoomId("guestUser")).thenReturn("room-123");
+        when(redisService.getChatRoom("room-123")).thenReturn(chatRoom);
+        chatRoom.addParticipant(ChatUser.builder().userId("guestUser").build());
+
+        chatRoomService.processAndPrivateMessage(message, "guestUser");
+
+        verify(messageBroadcaster).sendError("guestUser", "자기 자신에게는 메시지를 보낼 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("개인 메시지 전송 - 다른 방 유저에게 보낼 때")
+    void processAndPrivateMessage_recipientNotInRoom() {
+        ChatMessage message = ChatMessage.builder()
+                .roomId("room-123")
+                .recipient("otherUser")
+                .content("안녕")
+                .build();
+        when(redisService.getUserRoomId("guestUser")).thenReturn("room-123");
+        when(redisService.getChatRoom("room-123")).thenReturn(chatRoom);
+        chatRoom.addParticipant(ChatUser.builder().userId("guestUser").build());
+
+        chatRoomService.processAndPrivateMessage(message, "guestUser");
+
+        verify(messageBroadcaster).sendError("guestUser", "같은 방에 있는 사용자에게만 메시지를 보낼 수 있습니다.");
+    }
+
+    @Test
+    @DisplayName("개인 메시지 전송 - 성공")
+    void processAndPrivateMessage_success() {
+        ChatMessage message = ChatMessage.builder()
+                .roomId("room-123")
+                .recipient("hostUser")
+                .content("비밀 메시지")
+                .build();
+        when(redisService.getUserRoomId("guestUser")).thenReturn("room-123");
+        when(redisService.getChatRoom("room-123")).thenReturn(chatRoom);
+        chatRoom.addParticipant(ChatUser.builder().userId("guestUser").build());
+        when(gameQueryService.canPlayerChat("room-123", "guestUser")).thenReturn(true);
+        when(userService.getUserByLoginId("guestUser")).thenReturn(guest);
+
+        chatRoomService.processAndPrivateMessage(message, "guestUser");
+
+        verify(messageBroadcaster).sendPrivateMessage(eq("hostUser"), any(ChatMessage.class));
+    }
+
+    // ================== handleDisconnect Tests ================== //
+
+    @Test
+    @DisplayName("연결 종료 처리 - 게임 진행 중으로 재연결 대기")
+    void handleDisconnect_gameInProgress() {
+        when(redisService.getUserRoomId("guestUser")).thenReturn("room-123");
+        when(redisService.getChatRoom("room-123")).thenReturn(chatRoom);
+        when(gameQueryService.canPlayerLeaveRoom("room-123", "guestUser")).thenReturn(false);
+
+        chatRoomService.handleDisconnect("guestUser");
+
+        verify(redissonClient, never()).getLock(anyString());
+    }
+
+    @Test
+    @DisplayName("연결 종료 처리 - 게임 진행 중이 아니어서 퇴장 처리")
+    void handleDisconnect_leaveRoom() throws InterruptedException {
+        when(redisService.getUserRoomId("guestUser")).thenReturn("room-123");
+        when(redisService.getChatRoom("room-123")).thenReturn(chatRoom);
+        when(gameQueryService.canPlayerLeaveRoom("room-123", "guestUser")).thenReturn(true);
+        when(redissonClient.getLock("lock:room:room-123")).thenReturn(rLock);
+        when(rLock.tryLock(anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(true);
+        when(rLock.isHeldByCurrentThread()).thenReturn(true);
+
+        chatRoomService.handleDisconnect("guestUser");
+
+        verify(rLock).unlock();
+    }
+}

--- a/src/test/java/com/example/mafiagame/integration/ChatRoomIntegrationTest.java
+++ b/src/test/java/com/example/mafiagame/integration/ChatRoomIntegrationTest.java
@@ -76,6 +76,56 @@ class ChatRoomIntegrationTest extends RedisTestContainerSupport {
         assertThat(participants.size()).isEqualTo(2);
     }
 
+    @Test
+    @DisplayName("Create room -> Search rooms by keyword -> Get all rooms")
+    void searchAndListRooms() throws Exception {
+        TestUser host = registerAndLogin("searchHost");
+
+        // 1) Create room with specific name
+        String targetRoomName = "special-mafia-room-" + UUID.randomUUID().toString().substring(0, 4);
+        Map<String, String> createRoomBody = Map.of("roomName", targetRoomName);
+        mockMvc.perform(post("/api/chat/rooms")
+                        .header("Authorization", "Bearer " + host.accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createRoomBody)))
+                .andExpect(status().isCreated());
+
+        // 2) Get all rooms -> verify target room is present
+        MvcResult getAllResult = mockMvc.perform(get("/api/chat/rooms")
+                        .header("Authorization", "Bearer " + host.accessToken))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode allRoomsJson = objectMapper.readTree(getAllResult.getResponse().getContentAsString());
+        assertThat(allRoomsJson.isArray()).isTrue();
+        boolean foundInList = false;
+        for (JsonNode room : allRoomsJson) {
+            if (room.path("roomName").asText().equals(targetRoomName)) {
+                foundInList = true;
+                break;
+            }
+        }
+        assertThat(foundInList).isTrue();
+
+        // 3) Search rooms by keyword "special-mafia" -> verify target room is present
+        MvcResult searchResult = mockMvc.perform(get("/api/chat/rooms/search")
+                        .header("Authorization", "Bearer " + host.accessToken)
+                        .param("keyword", "special-mafia"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode searchRoomsJson = objectMapper.readTree(searchResult.getResponse().getContentAsString());
+        assertThat(searchRoomsJson.isArray()).isTrue();
+        boolean foundInSearch = false;
+        for (JsonNode room : searchRoomsJson) {
+            if (room.path("roomName").asText().equals(targetRoomName)) {
+                foundInSearch = true;
+                break;
+            }
+        }
+        assertThat(foundInSearch).isTrue();
+    }
+
     private TestUser registerAndLogin(String prefix) throws Exception {
         String suffix = UUID.randomUUID().toString().replace("-", "").substring(0, 6);
         String loginId = prefix + suffix;


### PR DESCRIPTION
## 변경 사항
- 채팅방 기본 최대 인원을 보정합니다.
- 채팅 컨트롤러, REST 컨트롤러, 서비스 단위 테스트를 추가합니다.
- 채팅방 목록/검색 통합 테스트를 보강합니다.

## 의존 관계
- Base: `refactor/develop-timer-feature`

## 검증
- `./gradlew test --tests "*ChatRoom*"`
- Docker 미실행으로 Redis 통합 테스트는 건너뜀