### PR TITLE
feat(user): add titles and auxiliary ranking cache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
+    // Circuit Breaker (Resilience4j)
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
+    implementation 'io.github.resilience4j:resilience4j-circuitbreaker:2.2.0'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
     implementation 'io.swagger.core.v3:swagger-annotations:2.2.20'

--- a/src/main/java/com/example/mafiagame/game/service/GameService.java
+++ b/src/main/java/com/example/mafiagame/game/service/GameService.java
@@ -14,6 +14,7 @@ import com.example.mafiagame.game.state.GamePhaseFactory;
 import com.example.mafiagame.game.state.GamePhaseState;
 import com.example.mafiagame.user.domain.Users;
 import com.example.mafiagame.user.repository.UsersRepository;
+import com.example.mafiagame.user.service.UserService;
 
 import java.util.concurrent.TimeUnit;
 
@@ -51,6 +52,7 @@ public class GameService {
     private final GameRepository gameRepository;
     private final GameStateRepository gameStateRepository;
     private final UsersRepository userRepository;
+    private final UserService userService;
     private final WebSocketMessageBroadcaster messageBroadcaster;
     private final StringRedisTemplate stringRedisTemplate;
     private final RedissonClient redissonClient;
@@ -66,6 +68,7 @@ public class GameService {
             GameRepository gameRepository,
             GameStateRepository gameStateRepository,
             UsersRepository userRepository,
+            UserService userService,
             WebSocketMessageBroadcaster messageBroadcaster,
             @Qualifier("coreStringRedisTemplate") StringRedisTemplate stringRedisTemplate,
             @Qualifier("coreRedissonClient") RedissonClient redissonClient,
@@ -77,6 +80,7 @@ public class GameService {
         this.gameRepository = gameRepository;
         this.gameStateRepository = gameStateRepository;
         this.userRepository = userRepository;
+        this.userService = userService;
         this.messageBroadcaster = messageBroadcaster;
         this.stringRedisTemplate = stringRedisTemplate;
         this.redissonClient = redissonClient;
@@ -362,11 +366,13 @@ public class GameService {
                     TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                         @Override
                         public void afterCommit() {
+                            userService.evictAuxiliaryRankingCache();
                             finalizeGameEnd(gameId, roomId, winnerTeam, playersSnapshot);
                         }
                     });
                 } else {
                     // 트랜잭션 비활성 환경(테스트 등)에서는 즉시 실행
+                    userService.evictAuxiliaryRankingCache();
                     finalizeGameEnd(gameId, roomId, winnerTeam, playersSnapshot);
                 }
 

--- a/src/main/java/com/example/mafiagame/global/config/CoreRedisCircuitBreakerConfig.java
+++ b/src/main/java/com/example/mafiagame/global/config/CoreRedisCircuitBreakerConfig.java
@@ -1,0 +1,29 @@
+package com.example.mafiagame.global.config;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Core Redis 서킷 브레이커 빈 등록.
+ * 실제 설정값은 application.properties의
+ * resilience4j.circuitbreaker.instances.coreRedis.* 에서 관리된다.
+ */
+@Configuration
+public class CoreRedisCircuitBreakerConfig {
+
+    /**
+     * application.properties에 정의된 'coreRedis' 인스턴스 설정으로 CircuitBreaker 생성.
+     * <ul>
+     *   <li>실패율 50% 이상 → OPEN</li>
+     *   <li>슬로우 콜 500ms 이상 & 80% 이상 → OPEN</li>
+     *   <li>슬라이딩 윈도우 20개, 최소 10개 호출 후 판단</li>
+     *   <li>OPEN 상태 30초 대기 → HALF_OPEN → 5회 시도</li>
+     * </ul>
+     */
+    @Bean
+    public CircuitBreaker coreRedisCircuitBreaker(CircuitBreakerRegistry registry) {
+        return registry.circuitBreaker("coreRedis");
+    }
+}

--- a/src/main/java/com/example/mafiagame/global/service/CoreRedisPressureService.java
+++ b/src/main/java/com/example/mafiagame/global/service/CoreRedisPressureService.java
@@ -1,0 +1,64 @@
+package com.example.mafiagame.global.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Properties;
+
+@Service
+@Slf4j
+public class CoreRedisPressureService {
+
+    private final StringRedisTemplate coreStringRedisTemplate;
+    private final double corePressureThreshold;
+    private final boolean forceDbFallback;
+
+    public CoreRedisPressureService(
+            @Qualifier("coreStringRedisTemplate") StringRedisTemplate coreStringRedisTemplate,
+            @Value("${aux.lookup.core-pressure-threshold:0.85}") double corePressureThreshold,
+            @Value("${aux.lookup.force-db-fallback:false}") boolean forceDbFallback) {
+        this.coreStringRedisTemplate = coreStringRedisTemplate;
+        this.corePressureThreshold = corePressureThreshold;
+        this.forceDbFallback = forceDbFallback;
+    }
+
+    public boolean shouldUseDbFallback() {
+        return forceDbFallback || isCoreRedisUnderPressure();
+    }
+
+    public boolean isUnderPressure() {
+        return isCoreRedisUnderPressure();
+    }
+
+    public boolean isCoreRedisUnderPressure() {
+        try {
+            Properties memoryInfo = coreStringRedisTemplate.execute(
+                    (RedisCallback<Properties>) connection -> connection.serverCommands().info("memory"));
+            if (memoryInfo == null) {
+                return false;
+            }
+
+            long usedMemory = parseLong(memoryInfo.getProperty("used_memory"));
+            long maxMemory = parseLong(memoryInfo.getProperty("maxmemory"));
+            if (maxMemory <= 0) {
+                return false;
+            }
+
+            return (double) usedMemory / maxMemory >= corePressureThreshold;
+        } catch (RuntimeException e) {
+            log.warn("Core Redis memory pressure check failed: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private long parseLong(String value) {
+        if (value == null || value.isBlank()) {
+            return 0L;
+        }
+        return Long.parseLong(value.trim());
+    }
+}

--- a/src/main/java/com/example/mafiagame/global/service/RedisRouter.java
+++ b/src/main/java/com/example/mafiagame/global/service/RedisRouter.java
@@ -1,0 +1,137 @@
+package com.example.mafiagame.global.service;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.function.Supplier;
+
+/**
+ * Core/Support Redis 라우팅 + 서킷 브레이커 통합 서비스.
+ *
+ * <p><b>정상 상태 (CLOSED)</b>: Core Redis(6379)로 게임 로직 라우팅.</p>
+ * <p><b>서킷 오픈 (OPEN)</b>: Support Redis(6380)가 Core의 메인 비즈니스 로직 분담.
+ * Support Redis의 read-through 캐시(Top10, 칭호)는 DB로 직접 폴백.</p>
+ *
+ * <p>모든 Core Redis 호출은 {@link #executeOnCore(Supplier)} 또는
+ * {@link #runOnCore(Runnable)}로 감싸 서킷 브레이커가 실패를 추적한다.</p>
+ */
+@Service
+@Slf4j
+public class RedisRouter {
+
+    private final StringRedisTemplate coreStringTemplate;
+    private final StringRedisTemplate supportStringTemplate;
+    private final RedisTemplate<String, Object> coreObjectTemplate;
+    private final RedisTemplate<String, Object> supportObjectTemplate;
+    private final RedissonClient coreRedisson;
+    private final RedissonClient supportRedisson;
+    private final CircuitBreaker circuitBreaker;
+
+    public RedisRouter(
+            @Qualifier("coreStringRedisTemplate") StringRedisTemplate coreStringTemplate,
+            @Qualifier("stringRedisTemplate") StringRedisTemplate supportStringTemplate,
+            @Qualifier("coreRedisTemplate") RedisTemplate<String, Object> coreObjectTemplate,
+            @Qualifier("redisTemplate") RedisTemplate<String, Object> supportObjectTemplate,
+            @Qualifier("coreRedissonClient") RedissonClient coreRedisson,
+            @Qualifier("redissonClient") RedissonClient supportRedisson,
+            CircuitBreakerRegistry circuitBreakerRegistry) {
+        this.coreStringTemplate = coreStringTemplate;
+        this.supportStringTemplate = supportStringTemplate;
+        this.coreObjectTemplate = coreObjectTemplate;
+        this.supportObjectTemplate = supportObjectTemplate;
+        this.coreRedisson = coreRedisson;
+        this.supportRedisson = supportRedisson;
+        this.circuitBreaker = circuitBreakerRegistry.circuitBreaker("coreRedis");
+
+        // 서킷 상태 변경 시 로깅
+        this.circuitBreaker.getEventPublisher()
+                .onStateTransition(event -> log.warn(
+                        "[RedisRouter] Circuit state changed: {} → {}",
+                        event.getStateTransition().getFromState(),
+                        event.getStateTransition().getToState()));
+    }
+
+    // ── 활성 템플릿 ──────────────────────────────────────────────
+
+    /**
+     * 서킷 상태에 따라 활성 StringRedisTemplate 반환.
+     * CLOSED → Core Redis, OPEN/FORCED_OPEN → Support Redis.
+     */
+    public StringRedisTemplate activeStringTemplate() {
+        return isCircuitOpen() ? supportStringTemplate : coreStringTemplate;
+    }
+
+    /**
+     * 서킷 상태에 따라 활성 RedisTemplate&lt;String, Object&gt; 반환.
+     */
+    public RedisTemplate<String, Object> activeObjectTemplate() {
+        return isCircuitOpen() ? supportObjectTemplate : coreObjectTemplate;
+    }
+
+    /**
+     * 서킷 상태에 따라 활성 RedissonClient 반환.
+     */
+    public RedissonClient activeRedisson() {
+        return isCircuitOpen() ? supportRedisson : coreRedisson;
+    }
+
+    // ── 서킷 브레이커로 감싼 Core Redis 실행 ──────────────────────
+
+    /**
+     * 반환값이 있는 Core Redis 작업을 서킷 브레이커로 감싸 실행.
+     * 서킷이 이미 OPEN이면 CallNotPermittedException이 발생하며,
+     * 호출자는 이를 catch하여 Support Redis 또는 DB 폴백을 수행해야 한다.
+     */
+    public <T> T executeOnCore(Supplier<T> operation) {
+        return circuitBreaker.executeSupplier(operation);
+    }
+
+    /**
+     * 반환값이 없는 Core Redis 작업을 서킷 브레이커로 감싸 실행.
+     */
+    public void runOnCore(Runnable operation) {
+        circuitBreaker.executeRunnable(operation);
+    }
+
+    // ── 상태 조회 ────────────────────────────────────────────────
+
+    /**
+     * 서킷이 OPEN 또는 FORCED_OPEN 상태인지 반환.
+     * true이면 Support Redis가 Core 역할을 분담하고,
+     * Support의 read-through 캐시는 DB를 직접 조회한다.
+     */
+    public boolean isCircuitOpen() {
+        CircuitBreaker.State state = circuitBreaker.getState();
+        return state == CircuitBreaker.State.OPEN
+                || state == CircuitBreaker.State.FORCED_OPEN;
+    }
+
+    /**
+     * Support Redis의 read-through 캐시(Top10, 칭호)를 우회해서 DB를 직접 조회해야 하는지 반환.
+     * 서킷이 열려 Support Redis가 게임 로직을 처리하는 동안에는 캐시 대신 DB를 직접 사용한다.
+     */
+    public boolean shouldBypassSupportCache() {
+        return isCircuitOpen();
+    }
+
+    /**
+     * 현재 서킷 브레이커 상태 문자열 반환 (모니터링/로깅 용도).
+     */
+    public String getCircuitState() {
+        return circuitBreaker.getState().name();
+    }
+
+    /**
+     * Core Redis 전용 StringRedisTemplate 직접 접근 (CoreRedisPressureService 등 모니터링 용도).
+     * 일반 비즈니스 로직에서는 activeStringTemplate()을 사용한다.
+     */
+    public StringRedisTemplate coreStringTemplate() {
+        return coreStringTemplate;
+    }
+}

--- a/src/main/java/com/example/mafiagame/user/controller/UserController.java
+++ b/src/main/java/com/example/mafiagame/user/controller/UserController.java
@@ -69,7 +69,9 @@ public class UserController {
         Map<String, Object> userInfo = Map.of(
                 "userId", users.getUserId(),
                 "userLoginId", users.getUserLoginId(),
-                "nickname", users.getNickname());
+                "nickname", users.getNickname(),
+                "title", users.getTitle().name(),
+                "titleDisplayName", users.getTitle().getDisplayName());
 
         return ResponseEntity.ok(CommonResponse.success(userInfo, "현재 사용자 정보 조회 성공"));
     }

--- a/src/main/java/com/example/mafiagame/user/domain/UserTitle.java
+++ b/src/main/java/com/example/mafiagame/user/domain/UserTitle.java
@@ -1,0 +1,35 @@
+package com.example.mafiagame.user.domain;
+
+public enum UserTitle {
+    ROOKIE("신입 시민"),
+    SURVIVOR("생존 전문가"),
+    STRATEGIST("전략가"),
+    ACE("승부사"),
+    LEGEND("전설");
+
+    private final String displayName;
+
+    UserTitle(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public static UserTitle fromStats(int playCount, double winRate) {
+        if (playCount >= 200 && winRate >= 0.65) {
+            return LEGEND;
+        }
+        if (playCount >= 100 && winRate >= 0.58) {
+            return ACE;
+        }
+        if (playCount >= 50 && winRate >= 0.52) {
+            return STRATEGIST;
+        }
+        if (playCount >= 20) {
+            return SURVIVOR;
+        }
+        return ROOKIE;
+    }
+}

--- a/src/main/java/com/example/mafiagame/user/domain/Users.java
+++ b/src/main/java/com/example/mafiagame/user/domain/Users.java
@@ -79,4 +79,8 @@ public class Users {
     public void incrementPlayCount() {
         this.playCount++;
     }
+
+    public UserTitle getTitle() {
+        return UserTitle.fromStats(this.playCount, this.winRate != null ? this.winRate : 0.0);
+    }
 }

--- a/src/main/java/com/example/mafiagame/user/dto/reponse/Top10UserResponse.java
+++ b/src/main/java/com/example/mafiagame/user/dto/reponse/Top10UserResponse.java
@@ -3,5 +3,7 @@ package com.example.mafiagame.user.dto.reponse;
 public record Top10UserResponse(
         String nickname,
         Double winRate,
-        int playCount) {
+        int playCount,
+        String title,
+        String titleDisplayName) {
 }

--- a/src/main/java/com/example/mafiagame/user/dto/reponse/UserDetailForUser.java
+++ b/src/main/java/com/example/mafiagame/user/dto/reponse/UserDetailForUser.java
@@ -1,10 +1,17 @@
 package com.example.mafiagame.user.dto.reponse;
 
+import com.example.mafiagame.user.domain.Users;
+
 public record UserDetailForUser(
-        String nickname
-        // 유저 레벨, 승률, 해당 방 점수
+        String nickname,
+        String title,
+        String titleDisplayName
 ) {
     public UserDetailForUser(String nickname) {
-        this.nickname = nickname;
+        this(nickname, null, null);
+    }
+
+    public UserDetailForUser(Users users) {
+        this(users.getNickname(), users.getTitle().name(), users.getTitle().getDisplayName());
     }
 }

--- a/src/main/java/com/example/mafiagame/user/repository/UsersRepository.java
+++ b/src/main/java/com/example/mafiagame/user/repository/UsersRepository.java
@@ -12,8 +12,6 @@ import org.springframework.stereotype.Repository;
 
 import com.example.mafiagame.user.domain.AuthProvider;
 import com.example.mafiagame.user.domain.Users;
-import com.example.mafiagame.user.dto.reponse.Top10UserResponse;
-
 @Repository
 public interface UsersRepository extends JpaRepository<Users, Long> {
     Optional<Users> findByUserLoginId(String userLoginId);
@@ -22,11 +20,9 @@ public interface UsersRepository extends JpaRepository<Users, Long> {
 
     List<Users> findAllByUserLoginIdIn(List<String> userLoginIds);
 
-    @Query("SELECT new com.example.mafiagame.user.dto.reponse.Top10UserResponse(" +
-            "u.nickname, u.winRate, u.playCount) " +
-            "FROM Users u WHERE u.playCount > 50 " +
+    @Query("SELECT u FROM Users u WHERE u.playCount > 50 " +
             "ORDER BY u.winRate DESC, u.playCount DESC")
-    List<Top10UserResponse> findTopRanking(Pageable pageable);
+    List<Users> findTopRanking(Pageable pageable);
 
     /**
      * 원자적 전적 업데이트 (단일 UPDATE 쿼리로 동시성 안전)

--- a/src/main/java/com/example/mafiagame/user/service/UserService.java
+++ b/src/main/java/com/example/mafiagame/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.example.mafiagame.user.service;
 
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -9,13 +10,18 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.example.mafiagame.global.error.CommonException;
 import com.example.mafiagame.global.error.ErrorCode;
 import com.example.mafiagame.global.jwt.JwtUtil;
 import com.example.mafiagame.global.jwt.RefreshTokenService;
+import com.example.mafiagame.global.service.CoreRedisPressureService;
 import com.example.mafiagame.user.domain.Users;
 import static com.example.mafiagame.user.domain.UserRole.USER;
 
+import java.time.Duration;
 import java.util.List;
 
 import com.example.mafiagame.user.dto.reponse.TokenResponse;
@@ -37,6 +43,12 @@ public class UserService {
     private final AuthenticationManager authenticationManager;
     private final JwtUtil jwtUtil;
     private final RefreshTokenService refreshTokenService;
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+    private final CoreRedisPressureService coreRedisPressureService;
+
+    private static final String TOP_RANKING_CACHE_KEY = "aux:user:ranking:win-rate:top10";
+    private static final Duration TOP_RANKING_CACHE_TTL = Duration.ofSeconds(30);
 
     // 유저 회원가입
     public void registerUser(RegistRequest request) {
@@ -78,7 +90,7 @@ public class UserService {
     public UserDetailForUser getUserDetailForUser(Long userId) {
         Users users = userRepository.findById(userId)
                 .orElseThrow(ErrorCode.USER_NOT_FOUND::commonException);
-        return new UserDetailForUser(users.getNickname());
+        return new UserDetailForUser(users);
     }
 
     // 유저 상세정보 ( 관리자용 )
@@ -127,6 +139,64 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public List<Top10UserResponse> getTopRanking() {
-        return userRepository.findTopRanking(PageRequest.of(0, 10));
+        if (isCoreRedisUnderPressure()) {
+            return findTopRankingFromDatabase();
+        }
+
+        String cached;
+        try {
+            cached = stringRedisTemplate.opsForValue().get(TOP_RANKING_CACHE_KEY);
+        } catch (RuntimeException e) {
+            return findTopRankingFromDatabase();
+        }
+
+        if (cached != null) {
+            try {
+                return objectMapper.readValue(cached, new TypeReference<List<Top10UserResponse>>() {
+                });
+            } catch (JsonProcessingException e) {
+                evictAuxiliaryRankingCache();
+            }
+        }
+
+        List<Top10UserResponse> ranking = findTopRankingFromDatabase();
+
+        try {
+            stringRedisTemplate.opsForValue().set(
+                    TOP_RANKING_CACHE_KEY,
+                    objectMapper.writeValueAsString(ranking),
+                    TOP_RANKING_CACHE_TTL);
+        } catch (JsonProcessingException | RuntimeException e) {
+            // Ranking remains available from DB even when the auxiliary cache write fails.
+        }
+        return ranking;
+    }
+
+    private boolean isCoreRedisUnderPressure() {
+        try {
+            return coreRedisPressureService.shouldUseDbFallback();
+        } catch (RuntimeException e) {
+            return true;
+        }
+    }
+
+    private List<Top10UserResponse> findTopRankingFromDatabase() {
+        List<Top10UserResponse> ranking = userRepository.findTopRanking(PageRequest.of(0, 10)).stream()
+                .map(user -> new Top10UserResponse(
+                        user.getNickname(),
+                        user.getWinRate(),
+                        user.getPlayCount(),
+                        user.getTitle().name(),
+                        user.getTitle().getDisplayName()))
+                .toList();
+        return ranking;
+    }
+
+    public void evictAuxiliaryRankingCache() {
+        try {
+            stringRedisTemplate.delete(TOP_RANKING_CACHE_KEY);
+        } catch (RuntimeException e) {
+            // Cache eviction is best-effort; ranking updates must not fail on Support Redis errors.
+        }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -39,6 +39,27 @@ mafiagame.redis.support.port=${SUPPORT_REDIS_PORT:${REDIS_SUPPORT_PORT:${REDIS_P
 mafiagame.redis.support.database=${SUPPORT_REDIS_DATABASE:${REDIS_SUPPORT_DATABASE:0}}
 mafiagame.redis.support.password=${SUPPORT_REDIS_PASSWORD:${REDIS_SUPPORT_PASSWORD:}}
 
+aux.lookup.core-pressure-threshold=${AUX_LOOKUP_CORE_PRESSURE_THRESHOLD:0.85}
+aux.lookup.force-db-fallback=${AUX_LOOKUP_FORCE_DB_FALLBACK:false}
+
+## Core Redis Circuit Breaker (Resilience4j)
+# 실패율 10% 이상이면 OPEN (sliding window 20개 호출 기준, 최소 10개 후 판단)
+resilience4j.circuitbreaker.instances.coreRedis.failure-rate-threshold=10
+resilience4j.circuitbreaker.instances.coreRedis.slow-call-rate-threshold=80
+resilience4j.circuitbreaker.instances.coreRedis.slow-call-duration-threshold=500ms
+resilience4j.circuitbreaker.instances.coreRedis.sliding-window-type=COUNT_BASED
+resilience4j.circuitbreaker.instances.coreRedis.sliding-window-size=20
+resilience4j.circuitbreaker.instances.coreRedis.minimum-number-of-calls=10
+resilience4j.circuitbreaker.instances.coreRedis.wait-duration-in-open-state=30s
+resilience4j.circuitbreaker.instances.coreRedis.permitted-number-of-calls-in-half-open-state=5
+resilience4j.circuitbreaker.instances.coreRedis.register-health-indicator=true
+resilience4j.circuitbreaker.instances.coreRedis.record-exceptions=org.springframework.dao.DataAccessException,java.util.concurrent.TimeoutException,io.lettuce.core.RedisException
+
+## Actuator (서킷 브레이커 모니터링)
+management.endpoints.web.exposure.include=health,info,prometheus,circuitbreakers
+management.endpoint.health.show-details=always
+management.health.circuitbreakers.enabled=true
+
 game.timer.worker.poll-delay-ms=500
 game.timer.worker.requeue-delay-ms=2000
 game.timer.worker.batch-size=20


### PR DESCRIPTION
## Summary

Adds user titles and a short-lived auxiliary Top10 ranking cache.

- User titles are derived from play count and win rate.
- Current-user, user-detail, and Top10 ranking responses expose title metadata.
- Top10 ranking reads from Support Redis cache when safe and falls back to DB when Core Redis is under pressure or cache access fails.
- Ranking cache is evicted after game result updates commit.
- Resilience4j coreRedis circuit breaker and Redis pressure helpers were added for auxiliary fallback decisions.

## Branch Split

This PR is stacked on codex/redis-core-support-split because it depends on the core/support Redis bean split.

## Validation

- ./gradlew test passed
- Testcontainers-based integration tests were skipped because Docker socket was unavailable in the Codex environment.